### PR TITLE
iOS NFC NDEF support

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -65,6 +65,8 @@
 	<false/>
 	<key>UIStatusBarStyle</key>
 	<string>UIStatusBarStyleLightContent</string>
+    <key>NFCReaderUsageDescription</key>
+    <string>Allow contactless Nano payments</string>    
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>

--- a/ios/Runner/Runner.entitlements
+++ b/ios/Runner/Runner.entitlements
@@ -4,5 +4,9 @@
 <dict>
 	<key>aps-environment</key>
 	<string>development</string>
+    <key>com.apple.developer.nfc.readersession.formats</key>
+    <array>
+        <string>NDEF</string>
+    </array>
 </dict>
 </plist>

--- a/lib/localization.dart
+++ b/lib/localization.dart
@@ -122,6 +122,11 @@ class AppLocalization {
       desc: 'intro_new_wallet_seed_copied', name: 'seedCopied');
   }
 
+  String get contactless {
+    return Intl.message('Contactless',
+        desc: 'send_contactless', name: 'contactless');
+  }
+
   String get scanQrCode {
     return Intl.message('Scan QR Code',
       desc: 'send_scan_qr', name: 'scanQrCode');

--- a/lib/ui/widgets/buttons.dart
+++ b/lib/ui/widgets/buttons.dart
@@ -208,4 +208,105 @@ class AppButton {
         throw new UIException("Invalid Button Type $type");
     }
   } //
+
+  static Widget buildAppButtonSplit(BuildContext context, AppButtonType type,
+      String leftText, String rightText, List<double> dimens,
+      {Function onLeftPressed, Function onRightPressed, bool disabled = false}) {
+    switch (type) {
+      case AppButtonType.PRIMARY_OUTLINE:
+        return Row( children:<Widget>[
+              Expanded(
+                  child: Container(
+                  decoration: BoxDecoration(
+                    color: StateContainer.of(context).curTheme.backgroundDark,
+                    borderRadius: BorderRadius.only(topLeft: Radius.circular(100), bottomLeft: Radius.circular(100)),
+                    boxShadow: [StateContainer.of(context).curTheme.boxShadowButton],
+                  ),
+                  height: 55,
+                  margin: EdgeInsetsDirectional.fromSTEB(dimens[0], dimens[1], 0, dimens[3]),
+                  child: OutlineButton(
+                    color: StateContainer.of(context).curTheme.backgroundDark,
+                    textColor: disabled
+                        ? StateContainer.of(context).curTheme.primary60
+                        : StateContainer.of(context).curTheme.primary,
+                    borderSide: BorderSide(
+                        color: disabled
+                            ? StateContainer.of(context).curTheme.primary60
+                            : StateContainer.of(context).curTheme.primary,
+                        width: 2.0),
+                    highlightedBorderColor: disabled
+                        ? StateContainer.of(context).curTheme.primary60
+                        : StateContainer.of(context).curTheme.primary,
+                    splashColor: StateContainer.of(context).curTheme.text30,
+                    highlightColor: StateContainer.of(context).curTheme.text15,
+                    shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.only(topLeft: Radius.circular(100), bottomLeft: Radius.circular(100))),
+                    child: AutoSizeText(
+                      leftText,
+                      textAlign: TextAlign.center,
+                      style: disabled
+                          ? AppStyles.textStyleButtonPrimaryOutlineDisabled(context)
+                          : AppStyles.textStyleButtonPrimaryOutline(context),
+                      maxLines: 1,
+                      stepGranularity: 0.5,
+                    ),
+                    onPressed: () {
+                      if (onLeftPressed != null) {
+                        onLeftPressed();
+                      }
+                      return;
+                    },
+                  ),
+                )
+              ),
+              Expanded(
+                  child: Container(
+                    decoration: BoxDecoration(
+                      color: StateContainer.of(context).curTheme.backgroundDark,
+                      borderRadius: BorderRadius.only(topRight: Radius.circular(100), bottomRight: Radius.circular(100)),
+                      boxShadow: [StateContainer.of(context).curTheme.boxShadowButton],
+                    ),
+                    height: 55,
+                    margin: EdgeInsetsDirectional.fromSTEB(0, dimens[1], dimens[2], dimens[3]),
+                    child: OutlineButton(
+                      color: StateContainer.of(context).curTheme.backgroundDark,
+                      textColor: disabled
+                          ? StateContainer.of(context).curTheme.primary60
+                          : StateContainer.of(context).curTheme.primary,
+                      borderSide: BorderSide(
+                          color: disabled
+                              ? StateContainer.of(context).curTheme.primary60
+                              : StateContainer.of(context).curTheme.primary,
+                          width: 2.0),
+                      highlightedBorderColor: disabled
+                          ? StateContainer.of(context).curTheme.primary60
+                          : StateContainer.of(context).curTheme.primary,
+                      splashColor: StateContainer.of(context).curTheme.text30,
+                      highlightColor: StateContainer.of(context).curTheme.text15,
+                      shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.only(topRight: Radius.circular(100), bottomRight: Radius.circular(100))),
+                      child: AutoSizeText(
+                        rightText,
+                        textAlign: TextAlign.center,
+                        style: disabled
+                            ? AppStyles.textStyleButtonPrimaryOutlineDisabled(context)
+                            : AppStyles.textStyleButtonPrimaryOutline(context),
+                        maxLines: 1,
+                        stepGranularity: 0.5,
+                      ),
+                      onPressed: () {
+                        if (onRightPressed != null) {
+                          onRightPressed();
+                        }
+                        return;
+                      },
+                    ),
+                )
+              )
+            ]
+        );
+      default:
+        throw new UIException("Invalid Button Type $type");
+    }
+  } //
 }

--- a/lib/util/deviceutil.dart
+++ b/lib/util/deviceutil.dart
@@ -1,0 +1,46 @@
+import 'dart:io';
+import 'package:device_info/device_info.dart';
+
+/// Utilities for device specific info
+class DeviceUtil {
+  /// Return true if this device is an iPhone7 or greater
+  static Future<bool> isIPhone7OrGreater() async {
+    if (!Platform.isIOS) {
+      return false;
+    }
+    IosDeviceInfo deviceInfo = await DeviceInfoPlugin().iosInfo;
+    String deviceIdentifier = deviceInfo.utsname.machine;
+    switch (deviceIdentifier) {
+      case 'iPhone5,1': // iPhone 5
+      case 'iPhone5,2': // iPhone 5
+      case 'iPhone5,3': // iPhone 5C
+      case 'iPhone5,4': // iPhone 5C
+      case 'iPhone6,1': // iPhone 5S
+      case 'iPhone6,2': // iPhone 5S
+      case 'iPhone7,2': // iPhone 6
+      case 'iPhone7,1': // iPhone 6 plus
+      case 'iPhone8,1': // iPhone 6s
+      case 'iPhone8,2': // iPhone 6s plus
+        return false;
+      default:
+        return true;
+    }
+  }
+
+  static Future<bool> isIOS11OrGreater() async {
+    if (!Platform.isIOS) {
+      return false;
+    }
+    IosDeviceInfo deviceInfo = await DeviceInfoPlugin().iosInfo;
+    String version = deviceInfo.systemVersion;
+    List<String> l = version.split('.');
+    if(l.length > 0){
+      return int.parse(l.elementAt(0)) >= 11;
+    }
+    return false;
+  }
+
+  static Future<bool> supportsNFCReader() async{
+    return await isIPhone7OrGreater() && await isIOS11OrGreater();
+  }
+}

--- a/lib/util/hapticutil.dart
+++ b/lib/util/hapticutil.dart
@@ -2,39 +2,16 @@ import 'dart:io';
 import 'package:flutter/services.dart';
 
 import 'package:vibrate/vibrate.dart';
-import 'package:device_info/device_info.dart';
+
+import 'package:natrium_wallet_flutter/util/deviceutil.dart';
 
 /// Utilities for haptic feedback
 class HapticUtil {
-  /// Return true if this device supports taptic engine (iPhone 7+)
-  Future<bool> hasTapicEngine() async {
-    if (!Platform.isIOS) {
-      return false;
-    }
-    IosDeviceInfo deviceInfo = await DeviceInfoPlugin().iosInfo;
-    String deviceIdentifier = deviceInfo.utsname.machine;
-    switch (deviceIdentifier) {
-      case 'iPhone5,1': // iPhone 5
-      case 'iPhone5,2': // iPhone 5
-      case 'iPhone5,3': // iPhone 5C
-      case 'iPhone5,4': // iPhone 5C
-      case 'iPhone6,1': // iPhone 5S
-      case 'iPhone6,2': // iPhone 5S
-      case 'iPhone7,2': // iPhone 6
-      case 'iPhone7,1': // iPhone 6 plus
-      case 'iPhone8,1': // iPhone 6s
-      case 'iPhone8,2': // iPhone 6s plus
-        return false;
-      default:
-        return true;
-    }
-  }
-
   /// Feedback for error
   Future<void> error() async {
     if (Platform.isIOS) {
-      // If this is simulator or this device doesnt have tapic then we can't use this
-      if (await hasTapicEngine() && await Vibrate.canVibrate) {
+      // If this is simulator or this device doesn't have tapic (iPhone 7+) then we can't use this
+      if (await DeviceUtil.isIPhone7OrGreater() && await Vibrate.canVibrate) {
         Vibrate.feedback(FeedbackType.error);
       } else {
         HapticFeedback.vibrate();
@@ -47,8 +24,8 @@ class HapticUtil {
   /// Feedback for success
   Future<void> success() async {
     if (Platform.isIOS) {
-      // If this is simulator or this device doesnt have tapic then we can't use this
-      if (await hasTapicEngine() && await Vibrate.canVibrate) {
+      // If this is simulator or this device doesn't have tapic (iPhone 7+) then we can't use this
+      if (await DeviceUtil.isIPhone7OrGreater() && await Vibrate.canVibrate) {
         Vibrate.feedback(FeedbackType.medium);
       } else {
         HapticFeedback.mediumImpact();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -91,11 +91,10 @@ dependencies:
   file_picker: ^1.3.8
 
   # Deep link support
-  #uni_links: ^0.2.0
   uni_links:
     git:
       url: https://github.com/CathalT/uni_links.git
-      ref: nfc_android
+      ref: nfc_support
 
   # HTTP client
   http: ^0.12.0+2


### PR DESCRIPTION
iOS was a bit more work than Android.
We need to manually start an NFC reader session, hence the addition of a "Contactless" button.

You can see the uni_link changes here:
https://github.com/avioli/uni_links/pull/36

Feel free to use these changes or come up with you're own UX, as this was a quick proof of concept that we used for our demo.

You will need to enable NFC entitlements on your apple developer page for the Natrium AppID.
NFC Reader is only supported on iPhone7 and upwards, and iOS 11 upwards.

