### PR TITLE
[Suggestion] Currency from locale not working as expected

### DIFF
--- a/lib/model/available_currency.dart
+++ b/lib/model/available_currency.dart
@@ -271,7 +271,7 @@ class AvailableCurrency extends SettingSelectionItem {
   static AvailableCurrency getBestForLocale(Locale locale) {
     AvailableCurrencyEnum.values.forEach((value) {
       AvailableCurrency currency = AvailableCurrency(value);
-      if (locale != null && locale.countryCode == null) {
+      if (locale != null && locale.countryCode != null) {
         // Special cases
         if (['AT', 'BE', 'CY', 'EE', 'FI', 'FR', 'DE', 'GR', 'IE', 'IT', 'LV', 'LT', 'LU', 'MT', 'NL', 'PT', 'SK', 'SI', 'ES'].contains(locale.countryCode)) {
           return AvailableCurrency(AvailableCurrencyEnum.EUR);


### PR DESCRIPTION
Hello
In the code snippet shown below, there is no way to get the currency based on local given that when the locale is supported `locale.countrycode` is not null, so it will not check for the currency. And in a country that is doesn’t have currency support, `locale.countrycode` will be null, and when trying to check if `currency.getLocale().countryCode.toUpperCase() == locale.countryCode.toUpperCase()` `toUpperCase()` will throw because `locale.countryCode` is null. So the work around for this is to change the condition to be: `if (locale != null && locale.countryCode != null)`.

![ern](https://user-images.githubusercontent.com/30930579/82112883-f002a000-9716-11ea-8984-127bdc001e64.jpg)

As described above, when using an unsupported country `toUpperCase()` was called on null:

![toupper](https://user-images.githubusercontent.com/30930579/82112897-1e807b00-9717-11ea-9c67-f36349d85a23.jpg)

This was found in the lib/model/available_currency.dart file.

