### PR TITLE
QR amount input

### DIFF
--- a/lib/ui/home_page.dart
+++ b/lib/ui/home_page.dart
@@ -676,6 +676,8 @@ class _AppHomePageState extends State<AppHomePage>
     painter.toImageData(MediaQuery.of(context).size.width).then((byteData) {
       setState(() {
         receive = ReceiveSheet(
+          localCurrency: StateContainer.of(context).curCurrency,
+          address: StateContainer.of(context).wallet.address,
           qrWidget: Container(
               width: MediaQuery.of(context).size.width / 2.675,
               child: Image.memory(byteData.buffer.asUint8List())),
@@ -833,7 +835,7 @@ class _AppHomePageState extends State<AppHomePage>
                             if (receive == null) {
                               return;
                             }
-                            Sheets.showAppHeightEightSheet(
+                            Sheets.showAppHeightNineSheet(
                                 context: context, widget: receive);
                           },
                           highlightColor: receive != null

--- a/lib/ui/receive/receive_sheet.dart
+++ b/lib/ui/receive/receive_sheet.dart
@@ -497,9 +497,13 @@ class _ReceiveSheetStateState extends State<ReceiveSheet> {
     if (_localCurrencyMode) {
       _lastLocalCurrencyAmount = _receiveAmountController.text;
       _lastCryptoAmount = _convertLocalCurrencyToCrypto();
-      raw = _lastCryptoAmount.length > 0 ? NumberUtil.getAmountAsRaw(_lastCryptoAmount) : '';
+      raw = _lastCryptoAmount.length > 0
+          ? NumberUtil.getAmountAsRaw(_lastCryptoAmount)
+          : '';
     } else {
-      raw = _receiveAmountController.text.length > 0 ? NumberUtil.getAmountAsRaw(_receiveAmountController.text) : '';
+      raw = _receiveAmountController.text.length > 0
+          ? NumberUtil.getAmountAsRaw(_receiveAmountController.text)
+          : '';
     }
     this.paintQrCode(address: widget.address, amount: raw);
   }
@@ -556,7 +560,8 @@ class _ReceiveSheetStateState extends State<ReceiveSheet> {
       maxLines: null,
       autocorrect: false,
       hintText:
-      _amountHint == null ? "" : AppLocalization.of(context).enterAmount + (_localCurrencyMode ?' (' + _localCurrencyFormat.currencySymbol +')' : ' (NANO)'),
+      _amountHint == null ? "" : AppLocalization.of(context).enterAmount +
+          (_localCurrencyMode ?' (' + _localCurrencyFormat.currencySymbol +')' : ' (NANO)'),
       prefixButton: TextFieldButton(
         icon: AppIcons.swapcurrency,
         onPressed: () {

--- a/lib/ui/receive/receive_sheet.dart
+++ b/lib/ui/receive/receive_sheet.dart
@@ -28,14 +28,14 @@ import 'package:flare_flutter/flare_actor.dart';
 
 class ReceiveSheet extends StatefulWidget {
   final AvailableCurrency localCurrency;
-  final Widget qrWidget;
   final String address;
+  final Widget qrWidget;
 
-  ReceiveSheet({
-    @required this.localCurrency,
-    this.address,
-    this.qrWidget}
-    ) : super();
+  ReceiveSheet(
+      {@required this.localCurrency,
+      this.address,
+      this.qrWidget})
+      : super();
 
   _ReceiveSheetStateState createState() => _ReceiveSheetStateState();
 }
@@ -51,12 +51,13 @@ class _ReceiveSheetStateState extends State<ReceiveSheet> {
   // Timer reference so we can cancel repeated events
   Timer _addressCopiedTimer;
 
-  // New vars
   FocusNode _receiveAmountFocusNode;
   TextEditingController _receiveAmountController;
+
   NumberFormat _localCurrencyFormat;
   bool _localCurrencyMode = false;
   String _amountHint = "";
+
   String _lastLocalCurrencyAmount = "";
   String _lastCryptoAmount = "";
 
@@ -555,7 +556,7 @@ class _ReceiveSheetStateState extends State<ReceiveSheet> {
       maxLines: null,
       autocorrect: false,
       hintText:
-      _amountHint == null ? "" : AppLocalization.of(context).enterAmount,
+      _amountHint == null ? "" : AppLocalization.of(context).enterAmount + (_localCurrencyMode ?' (' + _localCurrencyFormat.currencySymbol +')' : ' (NANO)'),
       prefixButton: TextFieldButton(
         icon: AppIcons.swapcurrency,
         onPressed: () {
@@ -565,12 +566,6 @@ class _ReceiveSheetStateState extends State<ReceiveSheet> {
       fadeSuffixOnCondition: true,
       keyboardType: TextInputType.numberWithOptions(decimal: true),
       textAlign: TextAlign.center,
-      // onSubmitted: (text) {
-      //   // FocusScope.of(context).unfocus();
-      //   // if (!Address(_sendAddressController.text).isValid()) {
-      //   //   FocusScope.of(context).requestFocus(_sendAddressFocusNode);
-      //   // }
-      // },
     );
   } //************ Enter Address Container Method End ************//
     //*************************************************************//

--- a/lib/ui/receive/receive_sheet.dart
+++ b/lib/ui/receive/receive_sheet.dart
@@ -497,7 +497,7 @@ class _ReceiveSheetStateState extends State<ReceiveSheet> {
     if (_localCurrencyMode) {
       _lastLocalCurrencyAmount = _receiveAmountController.text;
       _lastCryptoAmount = _convertLocalCurrencyToCrypto();
-      raw = NumberUtil.getAmountAsRaw(_lastCryptoAmount);
+      raw = _lastCryptoAmount.length > 0 ? NumberUtil.getAmountAsRaw(_lastCryptoAmount) : '';
     } else {
       raw = _receiveAmountController.text.length > 0 ? NumberUtil.getAmountAsRaw(_receiveAmountController.text) : '';
     }


### PR DESCRIPTION
This PR adds an amount input field to the receive sheet so it can be prefilled by the scanning device. The feature was suggested [here](https://www.reddit.com/r/nanocurrency/comments/kz5vob/request_an_amount_on_natrium/)

The current QR implementation creates the QR widget ahead of time and passes it into the receive sheet for performance reasons. I decided to keep it like this for the initial render. The QR widget is redrawn as the user enters the amount. I also tested only redrawing on blur/enter, but it didn't feel as nice IMO. If there is another approach that is preferable to this, let me know!

The input supports both NANO and local currency inputs which is converted to raw on the fly. This should be especially useful as a POS device for merchants with items listed in their native currency, since no separate currency calculation is needed.

![image](https://user-images.githubusercontent.com/1097444/105069359-1f299800-5a82-11eb-9f6b-e659cc98a228.png)
![image](https://user-images.githubusercontent.com/1097444/105069427-36688580-5a82-11eb-8f01-ec317670a18c.png)


