### PR TITLE
Upgrade flutter_svg to 0.22.0 

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -66,7 +66,7 @@ dependencies:
   event_taxi: ^1.0.0
 
   # SVG
-  flutter_svg: ^0.19.3
+  flutter_svg: ^0.22.0
     
   # QR Codes
   qr_flutter: ^2.0.1 # Generator


### PR DESCRIPTION
To avoid dependency resolution error: "So, because natrium_wallet_futter depends on both flutter_svg ^0.19.3 and intl_translation from git, version solving failed"

Signed-off-by: Calvin Cheng <linchuan.cheng@gmail.com>