### PR TITLE
Fixes display of south african (ZAR) currency from R$ to R

### DIFF
--- a/lib/model/available_currency.dart
+++ b/lib/model/available_currency.dart
@@ -212,7 +212,7 @@ class AvailableCurrency extends SettingSelectionItem {
       case "VES":
         return "VES";
       case "ZAR":
-        return "R\$";
+        return "R";
       case "UAH":
         return "₴";
       case "USD":


### PR DESCRIPTION
This is a small fix for the display of the South African Rand currency symbol.

Was including the $ along with the R. Eg: $R244.80 should be R244.80