### PR TITLE
Not for the 1st time, the QR was occluded

### DIFF
--- a/lib/ui/receive/share_card.dart
+++ b/lib/ui/receive/share_card.dart
@@ -63,22 +63,6 @@ class _AppShareCardState extends State<AppShareCard> {
                         child: qrSVG,
                       ),
                     ),
-                    // Actual QR part of the QR
-                    Center(
-                      child: Container(
-                        color: Colors.white,
-                        height: 64.6,
-                        width: 64.6,
-                        padding: EdgeInsets.all(2),
-                        child: QrImage(
-                          padding: EdgeInsets.all(0.0),
-                          data: StateContainer.of(context).wallet.address,
-                          version: 6,
-                          gapless: false,
-                          errorCorrectionLevel: QrErrorCorrectLevel.Q,
-                        ),
-                      ),
-                    ),
                     // Outer Ring
                     Center(
                       child: Container(
@@ -226,6 +210,23 @@ class _AppShareCardState extends State<AppShareCard> {
                               ),
                             ),
                           ),
+                    // Foreground Actual QR part of the QR
+                    // Don't cover it up
+                    Center(
+                      child: Container(
+                        color: Colors.white,
+                        height: 64.6,
+                        width: 64.6,
+                        padding: EdgeInsets.all(2),
+                        child: QrImage(
+                          padding: EdgeInsets.all(0.0),
+                          data: StateContainer.of(context).wallet.address,
+                          version: 6,
+                          gapless: false,
+                          errorCorrectionLevel: QrErrorCorrectLevel.Q,
+                        ),
+                      ),
+                    ),
                   ],
                 ),
               ),


### PR DESCRIPTION
There is some white line that is covering up parts of the QR code. Either that (alone), or combined with other false-flag QR shapes in the background, the camera apps haven't been able to consistently read the QR code.

I have no dart development experience, no local dev environment, but I'm hoping no one minds that I'm trying this anyway.